### PR TITLE
Change `Ignition` secret key name to key name to `ignition`

### DIFF
--- a/pkg/metal/create_machine.go
+++ b/pkg/metal/create_machine.go
@@ -78,7 +78,7 @@ func (d *metalDriver) applyServerClaim(ctx context.Context, req *driver.CreateMa
 	}
 
 	ignitionData := map[string][]byte{}
-	ignitionData["ignition.json"] = []byte(ignitionContent)
+	ignitionData["ignition"] = []byte(ignitionContent)
 	ignitionSecret := &corev1.Secret{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: corev1.SchemeGroupVersion.String(),

--- a/pkg/metal/create_machine_test.go
+++ b/pkg/metal/create_machine_test.go
@@ -90,7 +90,7 @@ var _ = Describe("CreateMachine", func() {
 		ignitionData, err := json.Marshal(testing.SampleIgnition)
 		Expect(err).NotTo(HaveOccurred())
 		Eventually(Object(ignition)).Should(SatisfyAll(
-			HaveField("Data", HaveKeyWithValue("ignition.json", MatchJSON(ignitionData))),
+			HaveField("Data", HaveKeyWithValue("ignition", MatchJSON(ignitionData))),
 		))
 
 		By("failing if the machine request is empty")

--- a/pkg/metal/driver.go
+++ b/pkg/metal/driver.go
@@ -17,7 +17,7 @@ import (
 )
 
 const (
-	defaultIgnitionKey     = "ignition.json"
+	defaultIgnitionKey     = "ignition"
 	ShootNameLabelKey      = "shoot-name"
 	ShootNamespaceLabelKey = "shoot-namespace"
 )

--- a/pkg/metal/testing/testing.go
+++ b/pkg/metal/testing/testing.go
@@ -20,7 +20,7 @@ var (
 			"name": "foo",
 		},
 		"image":             "my-image",
-		"ignitionSecretKey": "ignition.json",
+		"ignitionSecretKey": "ignition",
 		"ignition": `passwd:
   users:
     - groups: [group1]


### PR DESCRIPTION
# Proposed Changes
This fixes boot operator error `ignition data is missing`
