### PR TITLE
Fix ingition secret name length issue

### DIFF
--- a/kubernetes/machine-class.yaml
+++ b/kubernetes/machine-class.yaml
@@ -3,7 +3,7 @@ kind: MachineClass
 metadata:
   name: test-mc
   namespace: default # Namespace where the controller would watch
-provider: ironcore
+provider: metal
 providerSpec:
   # provider spec goes here ...
 secretRef: # Secret pointing to a secret which contains the provider secret and cloudconfig

--- a/pkg/metal/create_machine.go
+++ b/pkg/metal/create_machine.go
@@ -85,7 +85,7 @@ func (d *metalDriver) applyServerClaim(ctx context.Context, req *driver.CreateMa
 			Kind:       "Secret",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      getIgnitionNameForMachine(req.Machine.Name),
+			Name:      d.getIgnitionNameForMachine(ctx, req.Machine.Name),
 			Namespace: d.metalNamespace,
 		},
 		Data: ignitionData,
@@ -113,7 +113,7 @@ func (d *metalDriver) applyServerClaim(ctx context.Context, req *driver.CreateMa
 	}
 
 	if err := d.metalClient.Patch(ctx, serverClaim, client.Apply, fieldOwner, client.ForceOwnership); err != nil {
-		return nil, status.Error(codes.Internal, fmt.Sprintf("error applying ironcore machine: %s", err.Error()))
+		return nil, status.Error(codes.Internal, fmt.Sprintf("error applying metal machine: %s", err.Error()))
 	}
 
 	if err := d.metalClient.Patch(ctx, ignitionSecret, client.Apply, fieldOwner, client.ForceOwnership); err != nil {

--- a/pkg/metal/create_machine_test.go
+++ b/pkg/metal/create_machine_test.go
@@ -83,7 +83,7 @@ var _ = Describe("CreateMachine", func() {
 		ignition := &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: ns.Name,
-				Name:      fmt.Sprintf("%s-ignition", machineName),
+				Name:      machineName,
 			},
 		}
 

--- a/pkg/metal/delete_machine.go
+++ b/pkg/metal/delete_machine.go
@@ -35,7 +35,7 @@ func (d *metalDriver) DeleteMachine(ctx context.Context, req *driver.DeleteMachi
 
 	ignitionSecret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      getIgnitionNameForMachine(req.Machine.Name),
+			Name:      d.getIgnitionNameForMachine(ctx, req.Machine.Name),
 			Namespace: d.metalNamespace,
 		},
 	}


### PR DESCRIPTION
# Proposed Changes

- Creating the Ignition secret with the same name as the `Machine` name
- For backward compatibility checking if ignition secret was already present with old naming convention before creating/deleting with new name
- Update provider name in machine_class.yaml