### PR TITLE
Set logger for the controller runtime

### DIFF
--- a/pkg/client/provider.go
+++ b/pkg/client/provider.go
@@ -22,6 +22,7 @@ import (
 	"k8s.io/klog/v2"
 	capiv1beta1 "sigs.k8s.io/cluster-api/exp/ipam/api/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 type Provider struct {
@@ -38,6 +39,7 @@ func NewProviderAndNamespace(ctx context.Context, kubeconfigPath string) (*Provi
 	utilruntime.Must(metalv1alpha1.AddToScheme(cp.s))
 	utilruntime.Must(ipamv1alpha1.AddToScheme(cp.s))
 	utilruntime.Must(capiv1beta1.AddToScheme(cp.s))
+	ctrllog.SetLogger(klog.NewKlogr())
 
 	if err := cp.reloadMetalClientOnConfigChange(ctx); err != nil {
 		return nil, "", err


### PR DESCRIPTION
# Proposed Changes
When a function `New` from library `sigs.k8s.io/controller-runtime/pkg/client` is called without setting previously a logger for the controller runtime, there is a warning log:
```
[controller-runtime] log.SetLogger(...) was never called; logs will not be displayed.
Detected at:
        >  goroutine 136 [running]:
        >  runtime/debug.Stack()
        >       /usr/local/go/src/runtime/debug/stack.go:26 +0x5e
        >  sigs.k8s.io/controller-runtime/pkg/log.eventuallyFulfillRoot()
        >       /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.19.5/pkg/log/log.go:60 +0xcd
        >  sigs.k8s.io/controller-runtime/pkg/log.(*delegatingLogSink).WithName(0xc0002a8500, {0x236991c, 0x14})
        >       /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.19.5/pkg/log/deleg.go:147 +0x3e
        >  github.com/go-logr/logr.Logger.WithName({{0x26968b0, 0xc0002a8500}, 0x0}, {0x236991c?, 0x0?})
        >       /go/pkg/mod/github.com/go-logr/logr@v1.4.2/logr.go:345 +0x36
        >  sigs.k8s.io/controller-runtime/pkg/client.newClient(0x0?, {0x0, 0xc00022e930, {0x0, 0x0}, 0x0, 0x0})
        >       /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.19.5/pkg/client/client.go:118 +0xdb
        >  sigs.k8s.io/controller-runtime/pkg/client.New(0xc00091c180?, {0x0, 0xc00022e930, {0x0, 0x0}, 0x0, 0x0})
        >       /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.19.5/pkg/client/client.go:98 +0x55
        >  github.com/ironcore-dev/machine-controller-manager-provider-ironcore-metal/pkg/client.(*Provider).setMetalClient(0xc000528d80, {0x26939e0?, 0xc00091c180?})
        >       /workspace/pkg/client/provider.go:99 +0x156
        >  github.com/ironcore-dev/machine-controller-manager-provider-ironcore-metal/pkg/client.(*Provider).reloadMetalClientOnConfigChange.func1()
        >       /workspace/pkg/client/provider.go:145 +0x527
        >  created by github.com/ironcore-dev/machine-controller-manager-provider-ironcore-metal/pkg/client.(*Provider).reloadMetalClientOnConfigChange in goroutine 1
        >       /workspace/pkg/client/provider.go:121 +0x225
```