### PR TITLE
Remove `CSIDriverName` 

### DIFF
--- a/cmd/machine-controller/main.go
+++ b/cmd/machine-controller/main.go
@@ -22,7 +22,6 @@ import (
 
 var (
 	KubeconfigPath string
-	CSIDriverName  string
 )
 
 func main() {
@@ -42,7 +41,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	drv := metal.NewDriver(clientProvider, namespace, CSIDriverName)
+	drv := metal.NewDriver(clientProvider, namespace)
 	if err != nil {
 		_, _ = fmt.Fprintf(os.Stderr, "%v\n", err)
 		os.Exit(1)

--- a/pkg/metal/driver.go
+++ b/pkg/metal/driver.go
@@ -33,7 +33,6 @@ type metalDriver struct {
 	Schema         *runtime.Scheme
 	clientProvider *mcmclient.Provider
 	metalNamespace string
-	csiDriverName  string
 }
 
 func (d *metalDriver) InitializeMachine(ctx context.Context, request *driver.InitializeMachineRequest) (*driver.InitializeMachineResponse, error) {
@@ -45,11 +44,10 @@ func (d *metalDriver) GetVolumeIDs(_ context.Context, req *driver.GetVolumeIDsRe
 }
 
 // NewDriver returns a new Gardener metal driver object
-func NewDriver(cp *mcmclient.Provider, namespace, csiDriverName string) driver.Driver {
+func NewDriver(cp *mcmclient.Provider, namespace string) driver.Driver {
 	return &metalDriver{
 		clientProvider: cp,
 		metalNamespace: namespace,
-		csiDriverName:  csiDriverName,
 	}
 }
 

--- a/pkg/metal/suite_test.go
+++ b/pkg/metal/suite_test.go
@@ -138,7 +138,7 @@ func SetupTest() (*corev1.Namespace, *corev1.Secret, *driver.Driver) {
 		}
 		Expect(k8sClient.Create(ctx, secret)).To(Succeed())
 
-		drv = NewDriver(&mcmclient.Provider{Client: userClient}, ns.Name, "")
+		drv = NewDriver(&mcmclient.Provider{Client: userClient}, ns.Name)
 	})
 
 	return ns, secret, &drv


### PR DESCRIPTION
# Proposed Changes

Since we are not supporting any CSI specific configuration in the `ironcore-metal` MCM we can drop this field.
