### PR TITLE
Refactor IP address claim labels to use separate name and namespace keys

### DIFF
--- a/pkg/metal/create_machine_test.go
+++ b/pkg/metal/create_machine_test.go
@@ -150,7 +150,8 @@ var _ = Describe("CreateMachine", func() {
 
 			for _, ipClaim := range ipClaims {
 				Eventually(Object(ipClaim)).Should(SatisfyAll(
-					HaveField("Labels", HaveKeyWithValue(LabelKeyServerClaim, ServerClaim.Namespace+"_"+ServerClaim.Name)),
+					HaveField("Labels", HaveKeyWithValue(LabelKeyServerClaimName, ServerClaim.Name)),
+					HaveField("Labels", HaveKeyWithValue(LabelKeyServerClaimNamespace, ns.Name)),
 					HaveField("OwnerReferences", ContainElement(
 						metav1.OwnerReference{
 							APIVersion: metalv1alpha1.GroupVersion.String(),


### PR DESCRIPTION
# Proposed Changes

This change is needed because having name and namespace in one label can exceed label length limit.