### PR TITLE
Add polling of server claim before setting its ownership to ips

### DIFF
--- a/pkg/metal/create_machine.go
+++ b/pkg/metal/create_machine.go
@@ -274,10 +274,11 @@ func (d *metalDriver) setServerClaimOwnership(ctx context.Context, serverClaim *
 	defer d.clientProvider.Unlock()
 	metalClient := d.clientProvider.Client
 
+	// wait for the server claim to be visible in a cache
 	err := wait.PollUntilContextTimeout(
 		ctx,
-		time.Millisecond*50,
-		time.Millisecond*340,
+		50*time.Millisecond,
+		340*time.Millisecond,
 		true,
 		func(ctx context.Context) (bool, error) {
 			if err := metalClient.Get(ctx, client.ObjectKeyFromObject(serverClaim), serverClaim); err != nil {

--- a/pkg/metal/create_machine.go
+++ b/pkg/metal/create_machine.go
@@ -274,7 +274,18 @@ func (d *metalDriver) setServerClaimOwnership(ctx context.Context, serverClaim *
 	defer d.clientProvider.Unlock()
 	metalClient := d.clientProvider.Client
 
-	if err := metalClient.Get(ctx, client.ObjectKeyFromObject(serverClaim), serverClaim); err != nil {
+	err := wait.PollUntilContextTimeout(
+		ctx,
+		time.Millisecond*50,
+		time.Millisecond*340,
+		true,
+		func(ctx context.Context) (bool, error) {
+			if err := metalClient.Get(ctx, client.ObjectKeyFromObject(serverClaim), serverClaim); err != nil {
+				return false, err
+			}
+			return true, nil
+		})
+	if err != nil {
 		return err
 	}
 


### PR DESCRIPTION
# Proposed Changes

When an owner reference to a `ServerClaim` is made for `IPAddressClaim`s we need to wait until the `ServerClaim` is created so there is added polling.