### PR TITLE
Remove deprecated reviewers field from dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,8 +5,6 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    reviewers:
-      - "ironcore-dev/core"
     # Ignore K8 packages as these are done manually
     ignore:
       - dependency-name: "k8s.io/api"
@@ -22,11 +20,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    reviewers:
-      - "ironcore-dev/core"
   - package-ecosystem: "docker"
     directory: "/"
     schedule:
       interval: "weekly"
-    reviewers:
-      - "ironcore-dev/core"


### PR DESCRIPTION
# Proposed Changes

Remove deprecated reviewers field from dependabot config.