### PR TITLE
Allow to use `Server.Name` as the `Node` name of a `Machine`

### DIFF
--- a/cmd/machine-controller/main.go
+++ b/cmd/machine-controller/main.go
@@ -21,7 +21,8 @@ import (
 )
 
 var (
-	KubeconfigPath string
+	KubeconfigPath          string
+	UseServerNameAsNodeName bool
 )
 
 func main() {
@@ -41,11 +42,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	drv := metal.NewDriver(clientProvider, namespace)
-	if err != nil {
-		_, _ = fmt.Fprintf(os.Stderr, "%v\n", err)
-		os.Exit(1)
-	}
+	drv := metal.NewDriver(clientProvider, namespace, UseServerNameAsNodeName)
 
 	if err := app.Run(s, drv); err != nil {
 		_, _ = fmt.Fprintf(os.Stderr, "%v\n", err)
@@ -55,4 +52,5 @@ func main() {
 
 func AddExtraFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&KubeconfigPath, "metal-kubeconfig", "", "Path to the metal cluster kubeconfig.")
+	fs.BoolVar(&UseServerNameAsNodeName, "use-server-name-as-node-name", false, "Use server name as node name instead of server claim name.")
 }

--- a/cmd/machine-controller/main.go
+++ b/cmd/machine-controller/main.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/ironcore-dev/machine-controller-manager-provider-ironcore-metal/pkg/cmd"
+
 	_ "github.com/gardener/machine-controller-manager/pkg/util/client/metrics/prometheus" // for client metric registration
 	"github.com/gardener/machine-controller-manager/pkg/util/provider/app"
 	mcmoptions "github.com/gardener/machine-controller-manager/pkg/util/provider/app/options"
@@ -21,8 +23,8 @@ import (
 )
 
 var (
-	KubeconfigPath          string
-	UseServerNameAsNodeName bool
+	KubeconfigPath string
+	nodeNamePolicy cmd.NodeNamePolicy
 )
 
 func main() {
@@ -42,7 +44,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	drv := metal.NewDriver(clientProvider, namespace, UseServerNameAsNodeName)
+	drv := metal.NewDriver(clientProvider, namespace, nodeNamePolicy)
 
 	if err := app.Run(s, drv); err != nil {
 		_, _ = fmt.Fprintf(os.Stderr, "%v\n", err)
@@ -52,5 +54,5 @@ func main() {
 
 func AddExtraFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&KubeconfigPath, "metal-kubeconfig", "", "Path to the metal cluster kubeconfig.")
-	fs.BoolVar(&UseServerNameAsNodeName, "use-server-name-as-node-name", false, "Use server name as node name instead of server claim name.")
+	fs.Var(&nodeNamePolicy, "node-name-policy", "Define the node name policy. Possible values are 'ServerName' and 'ServerClaimName'.")
 }

--- a/pkg/cmd/types.go
+++ b/pkg/cmd/types.go
@@ -1,0 +1,33 @@
+// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and IronCore contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package cmd
+
+import "fmt"
+
+type NodeNamePolicy string
+
+const (
+	NodeNamePolicyServerName      NodeNamePolicy = "ServerName"
+	NodeNamePolicyServerClaimName NodeNamePolicy = "ServerClaimName"
+)
+
+// String returns the string representation of the NodeNamePolicy value
+func (n *NodeNamePolicy) String() string {
+	return string(*n)
+}
+
+func (n *NodeNamePolicy) Type() string {
+	return string(*n)
+}
+
+// Set validates and sets the NodeNamePolicy value
+func (n *NodeNamePolicy) Set(value string) error {
+	switch NodeNamePolicy(value) {
+	case NodeNamePolicyServerName, NodeNamePolicyServerClaimName:
+		*n = NodeNamePolicy(value)
+		return nil
+	default:
+		return fmt.Errorf("invalid NodeNamePolicy value: %s (must be 'ServerName' or 'ServerClaimName')", value)
+	}
+}

--- a/pkg/metal/create_machine.go
+++ b/pkg/metal/create_machine.go
@@ -59,18 +59,19 @@ func (d *metalDriver) CreateMachine(ctx context.Context, req *driver.CreateMachi
 		return nil, err
 	}
 
-	ignitionSecret, err := d.applyIgnition(ctx, req, providerSpec, addressesMetaData)
+	ignitionSecret, err := d.generateIgnition(ctx, req, req.Machine.Name, providerSpec, addressesMetaData)
 	if err != nil {
 		return nil, err
 	}
 
-	serverClaim, err := d.applyServerClaim(ctx, req, providerSpec, ignitionSecret)
+	serverClaim := d.generateServerClaim(req, providerSpec, ignitionSecret)
+
+	serverClaim, err = d.applyInitialServerClaimAndIgnition(ctx, serverClaim, ignitionSecret)
 	if err != nil {
 		return nil, err
 	}
 
-	err = d.setServerClaimOwnership(ctx, serverClaim, addressClaims)
-	if err != nil {
+	if err := d.setServerClaimOwnershipToIPAddressClaim(ctx, serverClaim, addressClaims); err != nil {
 		return nil, err
 	}
 
@@ -82,10 +83,57 @@ func (d *metalDriver) CreateMachine(ctx context.Context, req *driver.CreateMachi
 		nodeName = serverClaim.Spec.ServerRef.Name
 	}
 
+	if err := d.updateHostnameAndPowerOnServer(ctx, req, serverClaim, providerSpec, addressesMetaData, nodeName); err != nil {
+		return nil, status.Error(codes.Internal, err.Error())
+	}
+
 	return &driver.CreateMachineResponse{
 		ProviderID: getProviderIDForServerClaim(serverClaim),
 		NodeName:   nodeName,
 	}, nil
+}
+
+func (d *metalDriver) generateServerClaim(req *driver.CreateMachineRequest, spec *apiv1alpha1.ProviderSpec, secret *corev1.Secret) *metalv1alpha1.ServerClaim {
+	return &metalv1alpha1.ServerClaim{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: metalv1alpha1.GroupVersion.String(),
+			Kind:       "ServerClaim",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      req.Machine.Name,
+			Namespace: d.metalNamespace,
+			Labels:    spec.Labels,
+		},
+		Spec: metalv1alpha1.ServerClaimSpec{
+			Power: metalv1alpha1.PowerOff, // we will power on the server later
+			ServerSelector: &metav1.LabelSelector{
+				MatchLabels:      spec.ServerLabels,
+				MatchExpressions: nil,
+			},
+			IgnitionSecretRef: &corev1.LocalObjectReference{Name: secret.Name},
+			Image:             spec.Image,
+		},
+	}
+}
+
+func (d *metalDriver) updateHostnameAndPowerOnServer(ctx context.Context, req *driver.CreateMachineRequest, serverClaim *metalv1alpha1.ServerClaim, providerSpec *apiv1alpha1.ProviderSpec, addressesMetaData map[string]any, hostname string) error {
+	ignitionSecret, err := d.generateIgnition(ctx, req, hostname, providerSpec, addressesMetaData)
+	if err != nil {
+		return err
+	}
+
+	if err := d.clientProvider.Client.Patch(ctx, ignitionSecret, client.Apply, fieldOwner, client.ForceOwnership); err != nil {
+		return err
+	}
+
+	serverClaimBase := serverClaim.DeepCopy()
+	serverClaim.Spec.Power = metalv1alpha1.PowerOn
+
+	if err := d.clientProvider.Client.Patch(ctx, serverClaim, client.MergeFrom(serverClaimBase)); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 // isEmptyCreateRequest checks if any of the fields in CreateMachineRequest is empty
@@ -189,8 +237,8 @@ func (d *metalDriver) getOrCreateIPAddressClaims(ctx context.Context, req *drive
 	return ipAddressClaims, addressesMetaData, nil
 }
 
-// applyIgnition creates an ignition file for the machine and stores it in a secret
-func (d *metalDriver) applyIgnition(ctx context.Context, req *driver.CreateMachineRequest, providerSpec *apiv1alpha1.ProviderSpec, addressesMetaData map[string]any) (*corev1.Secret, error) {
+// generateIgnition creates an ignition file for the machine and stores it in a secret
+func (d *metalDriver) generateIgnition(ctx context.Context, req *driver.CreateMachineRequest, hostname string, providerSpec *apiv1alpha1.ProviderSpec, addressesMetaData map[string]any) (*corev1.Secret, error) {
 	// Get userData from machine secret
 	userData, ok := req.Secret.Data["userData"]
 	if !ok {
@@ -209,7 +257,7 @@ func (d *metalDriver) applyIgnition(ctx context.Context, req *driver.CreateMachi
 
 	// Construct ignition file config
 	config := &ignition.Config{
-		Hostname:         req.Machine.Name,
+		Hostname:         hostname,
 		UserData:         string(userData),
 		MetaData:         providerSpec.Metadata,
 		Ignition:         providerSpec.Ignition,
@@ -238,34 +286,13 @@ func (d *metalDriver) applyIgnition(ctx context.Context, req *driver.CreateMachi
 	return ignitionSecret, nil
 }
 
-// applyServerClaim reserves a Server by creating a corresponding ServerClaim object with proper ignition data
-func (d *metalDriver) applyServerClaim(ctx context.Context, req *driver.CreateMachineRequest, providerSpec *apiv1alpha1.ProviderSpec, ignitionSecret *corev1.Secret) (*metalv1alpha1.ServerClaim, error) {
-	serverClaim := &metalv1alpha1.ServerClaim{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: metalv1alpha1.GroupVersion.String(),
-			Kind:       "ServerClaim",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      req.Machine.Name,
-			Namespace: d.metalNamespace,
-			Labels:    providerSpec.Labels,
-		},
-		Spec: metalv1alpha1.ServerClaimSpec{
-			Power: "On",
-			ServerSelector: &metav1.LabelSelector{
-				MatchLabels:      providerSpec.ServerLabels,
-				MatchExpressions: nil,
-			},
-			IgnitionSecretRef: &corev1.LocalObjectReference{Name: ignitionSecret.Name},
-			Image:             providerSpec.Image,
-		},
-	}
-
+// applyInitialServerClaimAndIgnition reserves a Server by creating a corresponding ServerClaim object with proper ignition data
+func (d *metalDriver) applyInitialServerClaimAndIgnition(ctx context.Context, claim *metalv1alpha1.ServerClaim, ignitionSecret *corev1.Secret) (*metalv1alpha1.ServerClaim, error) {
 	d.clientProvider.Lock()
 	defer d.clientProvider.Unlock()
 	metalClient := d.clientProvider.Client
 
-	if err := metalClient.Patch(ctx, serverClaim, client.Apply, fieldOwner, client.ForceOwnership); err != nil {
+	if err := metalClient.Patch(ctx, claim, client.Apply, fieldOwner, client.ForceOwnership); err != nil {
 		return nil, status.Error(codes.Internal, fmt.Sprintf("error applying metal machine: %s", err.Error()))
 	}
 
@@ -275,10 +302,13 @@ func (d *metalDriver) applyServerClaim(ctx context.Context, req *driver.CreateMa
 
 	// Wait for the ServerClaim to claim a server
 	if err := wait.PollUntilContextTimeout(ctx, 1*time.Second, 3*time.Second, true, func(ctx context.Context) (bool, error) {
-		if err := metalClient.Get(ctx, client.ObjectKeyFromObject(serverClaim), serverClaim); err != nil {
+		if claim.Spec.ServerRef != nil { // early return if the server ref is already set
+			return true, nil
+		}
+		if err := metalClient.Get(ctx, client.ObjectKeyFromObject(claim), claim); err != nil {
 			return false, err
 		}
-		if serverClaim.Spec.ServerRef == nil {
+		if claim.Spec.ServerRef == nil {
 			return false, nil
 		}
 		return true, nil
@@ -286,11 +316,11 @@ func (d *metalDriver) applyServerClaim(ctx context.Context, req *driver.CreateMa
 		return nil, status.Error(codes.Internal, fmt.Sprintf("error waiting for server claim to claim a server: %s", err.Error()))
 	}
 
-	return serverClaim, nil
+	return claim, nil
 }
 
-// setServerClaimOwnership sets the owner reference of the IPAddressClaims to the ServerClaim
-func (d *metalDriver) setServerClaimOwnership(ctx context.Context, serverClaim *metalv1alpha1.ServerClaim, IPAddressClaims []*capiv1beta1.IPAddressClaim) error {
+// setServerClaimOwnershipToIPAddressClaim sets the owner reference of the IPAddressClaims to the ServerClaim
+func (d *metalDriver) setServerClaimOwnershipToIPAddressClaim(ctx context.Context, serverClaim *metalv1alpha1.ServerClaim, IPAddressClaims []*capiv1beta1.IPAddressClaim) error {
 	d.clientProvider.Lock()
 	defer d.clientProvider.Unlock()
 	metalClient := d.clientProvider.Client

--- a/pkg/metal/create_machine.go
+++ b/pkg/metal/create_machine.go
@@ -10,6 +10,8 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/ironcore-dev/machine-controller-manager-provider-ironcore-metal/pkg/cmd"
+
 	"github.com/imdario/mergo"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -76,7 +78,7 @@ func (d *metalDriver) CreateMachine(ctx context.Context, req *driver.CreateMachi
 	}
 
 	nodeName := serverClaim.Name
-	if d.useServerNameAsNodeName {
+	if d.nodeNamePolicy == cmd.NodeNamePolicyServerName {
 		if serverClaim.Spec.ServerRef == nil {
 			return nil, status.Error(codes.Internal, "server claim does not have a server ref")
 		}

--- a/pkg/metal/create_machine_test.go
+++ b/pkg/metal/create_machine_test.go
@@ -25,31 +25,6 @@ import (
 var _ = Describe("CreateMachine", func() {
 	ns, providerSecret, drv := SetupTest()
 
-	var server *metalv1alpha1.Server
-
-	BeforeEach(func(ctx SpecContext) {
-		By("creating a server")
-		server = &metalv1alpha1.Server{
-			ObjectMeta: metav1.ObjectMeta{
-				GenerateName: "server-",
-				Labels: map[string]string{
-					"instance-type": "machine-class",
-				},
-			},
-			Spec: metalv1alpha1.ServerSpec{
-				UUID:  "12345",
-				Power: "On",
-			},
-		}
-		Expect(k8sClient.Create(ctx, server)).To(Succeed())
-		DeferCleanup(k8sClient.Delete, server)
-
-		By("ensuring the server is in an available state")
-		Eventually(UpdateStatus(server, func() {
-			server.Status.State = metalv1alpha1.ServerStateAvailable
-		})).Should(Succeed())
-	})
-
 	It("should create a machine", func(ctx SpecContext) {
 		machineName := "machine-0"
 
@@ -228,5 +203,79 @@ var _ = Describe("CreateMachine", func() {
 				Expect(k8sClient.Delete(ctx, ip)).To(Succeed())
 			}
 		})
+	})
+})
+
+var _ = Describe("CreateMachine with Server name as hostname", func() {
+	ns, providerSecret, drv := SetupTestUsingServerNames()
+
+	It("should create a machine", func(ctx SpecContext) {
+		machineName := "machine-0"
+
+		By("starting a non-blocking goroutine to patch ServerClaim")
+		go func() {
+			defer GinkgoRecover()
+			serverClaim := &metalv1alpha1.ServerClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: ns.Name,
+					Name:      machineName,
+				},
+			}
+			Eventually(Update(serverClaim, func() {
+				serverClaim.Spec.ServerRef = &corev1.LocalObjectReference{Name: "foo"}
+			})).Should(Succeed())
+		}()
+
+		By("creating machine")
+		Expect((*drv).CreateMachine(ctx, &driver.CreateMachineRequest{
+			Machine:      newMachine(ns, "machine", -1, nil),
+			MachineClass: newMachineClass(v1alpha1.ProviderName, testing.SampleProviderSpec),
+			Secret:       providerSecret,
+		})).To(Equal(&driver.CreateMachineResponse{
+			ProviderID: fmt.Sprintf("%s://%s/machine-%d", v1alpha1.ProviderName, ns.Name, 0),
+			NodeName:   "foo",
+		}))
+
+		By("ensuring that a server claim has been created")
+		serverClaim := &metalv1alpha1.ServerClaim{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      machineName,
+				Namespace: ns.Name,
+			},
+		}
+
+		Eventually(Object(serverClaim)).Should(SatisfyAll(
+			HaveField("ObjectMeta.Labels", map[string]string{
+				ShootNameLabelKey:      "my-shoot",
+				ShootNamespaceLabelKey: "my-shoot-namespace",
+			}),
+			HaveField("Spec.Power", metalv1alpha1.PowerOn),
+			HaveField("Spec.ServerSelector", &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"instance-type": "bar",
+				},
+			}),
+		))
+
+		By("ensuring that the ignition secret has been created")
+		ignition := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: ns.Name,
+				Name:      machineName,
+			},
+		}
+
+		ignitionData, err := json.Marshal(testing.SampleIgnitionWithFooHostname)
+		Expect(err).NotTo(HaveOccurred())
+		Eventually(Object(ignition)).Should(SatisfyAll(
+			HaveField("Data", HaveKeyWithValue("ignition", MatchJSON(ignitionData))),
+		))
+
+		By("failing if the machine request is empty")
+		Eventually(func(g Gomega) {
+			_, err := (*drv).CreateMachine(ctx, nil)
+			g.Expect(err.Error()).To(ContainSubstring("received empty request"))
+		}).Should(Succeed())
+
 	})
 })

--- a/pkg/metal/create_machine_test.go
+++ b/pkg/metal/create_machine_test.go
@@ -9,6 +9,8 @@ import (
 	"fmt"
 	"maps"
 
+	"github.com/ironcore-dev/machine-controller-manager-provider-ironcore-metal/pkg/cmd"
+
 	"github.com/gardener/machine-controller-manager/pkg/util/provider/driver"
 	"github.com/ironcore-dev/machine-controller-manager-provider-ironcore-metal/pkg/api/v1alpha1"
 	"github.com/ironcore-dev/machine-controller-manager-provider-ironcore-metal/pkg/metal/testing"
@@ -23,7 +25,7 @@ import (
 )
 
 var _ = Describe("CreateMachine", func() {
-	ns, providerSecret, drv := SetupTest()
+	ns, providerSecret, drv := SetupTest(cmd.NodeNamePolicyServerClaimName)
 
 	It("should create a machine", func(ctx SpecContext) {
 		machineName := "machine-0"
@@ -92,7 +94,9 @@ var _ = Describe("CreateMachine", func() {
 			_, err := (*drv).CreateMachine(ctx, nil)
 			g.Expect(err.Error()).To(ContainSubstring("received empty request"))
 		}).Should(Succeed())
+	})
 
+	It("should fail if the machine class is empty", func(ctx SpecContext) {
 		By("failing if the wrong provider is set")
 		Eventually(func(g Gomega) {
 			_, err := (*drv).CreateMachine(ctx, &driver.CreateMachineRequest{
@@ -207,7 +211,7 @@ var _ = Describe("CreateMachine", func() {
 })
 
 var _ = Describe("CreateMachine with Server name as hostname", func() {
-	ns, providerSecret, drv := SetupTestUsingServerNames()
+	ns, providerSecret, drv := SetupTest(cmd.NodeNamePolicyServerName)
 
 	It("should create a machine", func(ctx SpecContext) {
 		machineName := "machine-0"

--- a/pkg/metal/delete_machine_test.go
+++ b/pkg/metal/delete_machine_test.go
@@ -22,6 +22,21 @@ var _ = Describe("DeleteMachine", func() {
 	ns, providerSecret, drv := SetupTest()
 
 	It("should create and delete a machine", func(ctx SpecContext) {
+		machineName := "machine-0"
+
+		go func() {
+			defer GinkgoRecover()
+			serverClaim := &metalv1alpha1.ServerClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: ns.Name,
+					Name:      machineName,
+				},
+			}
+			Eventually(Update(serverClaim, func() {
+				serverClaim.Spec.ServerRef = &corev1.LocalObjectReference{Name: "foo"}
+			})).Should(Succeed())
+		}()
+
 		By("creating an metal machine")
 		Expect((*drv).CreateMachine(ctx, &driver.CreateMachineRequest{
 			Machine:      newMachine(ns, "machine", -1, nil),
@@ -29,20 +44,20 @@ var _ = Describe("DeleteMachine", func() {
 			Secret:       providerSecret,
 		})).To(Equal(&driver.CreateMachineResponse{
 			ProviderID: fmt.Sprintf("%s://%s/machine-%d", v1alpha1.ProviderName, ns.Name, 0),
-			NodeName:   "machine-0",
+			NodeName:   machineName,
 		}))
 
 		serverClaim := &metalv1alpha1.ServerClaim{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: ns.Name,
-				Name:      "machine-0",
+				Name:      machineName,
 			},
 		}
 
 		ignition := &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: ns.Name,
-				Name:      "machine-0",
+				Name:      machineName,
 			},
 		}
 
@@ -63,13 +78,30 @@ var _ = Describe("DeleteMachine", func() {
 	})
 
 	It("should create and delete a machine igntition secret created with old naming convention", func(ctx SpecContext) {
+		machineName := "machine-0"
+
 		By("creating an ignition secret")
 		ignition := &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: ns.Name,
-				Name:      "machine-0",
+				Name:      machineName,
 			},
 		}
+
+		By("starting a non-blocking goroutine to patch ServerClaim")
+		go func() {
+			defer GinkgoRecover()
+			serverClaim := &metalv1alpha1.ServerClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: ns.Name,
+					Name:      machineName,
+				},
+			}
+			Eventually(Update(serverClaim, func() {
+				serverClaim.Spec.ServerRef = &corev1.LocalObjectReference{Name: "foo"}
+			})).Should(Succeed())
+		}()
+
 		By("creating an metal machine")
 		Expect((*drv).CreateMachine(ctx, &driver.CreateMachineRequest{
 			Machine:      newMachine(ns, "machine", -1, nil),
@@ -77,13 +109,13 @@ var _ = Describe("DeleteMachine", func() {
 			Secret:       providerSecret,
 		})).To(Equal(&driver.CreateMachineResponse{
 			ProviderID: fmt.Sprintf("%s://%s/machine-%d", v1alpha1.ProviderName, ns.Name, 0),
-			NodeName:   "machine-0",
+			NodeName:   machineName,
 		}))
 
 		serverClaim := &metalv1alpha1.ServerClaim{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: ns.Name,
-				Name:      "machine-0",
+				Name:      machineName,
 			},
 		}
 

--- a/pkg/metal/delete_machine_test.go
+++ b/pkg/metal/delete_machine_test.go
@@ -19,7 +19,7 @@ import (
 )
 
 var _ = Describe("DeleteMachine", func() {
-	ns, providerSecret, drv := SetupTest()
+	ns, providerSecret, drv := SetupTest("")
 
 	It("should create and delete a machine", func(ctx SpecContext) {
 		machineName := "machine-0"

--- a/pkg/metal/driver.go
+++ b/pkg/metal/driver.go
@@ -7,6 +7,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/ironcore-dev/machine-controller-manager-provider-ironcore-metal/pkg/cmd"
+
 	"github.com/gardener/machine-controller-manager/pkg/util/provider/driver"
 	"github.com/gardener/machine-controller-manager/pkg/util/provider/machinecodes/codes"
 	"github.com/gardener/machine-controller-manager/pkg/util/provider/machinecodes/status"
@@ -30,26 +32,26 @@ var (
 )
 
 type metalDriver struct {
-	Schema                  *runtime.Scheme
-	clientProvider          *mcmclient.Provider
-	metalNamespace          string
-	useServerNameAsNodeName bool
+	Schema         *runtime.Scheme
+	clientProvider *mcmclient.Provider
+	metalNamespace string
+	nodeNamePolicy cmd.NodeNamePolicy
 }
 
-func (d *metalDriver) InitializeMachine(ctx context.Context, request *driver.InitializeMachineRequest) (*driver.InitializeMachineResponse, error) {
+func (d *metalDriver) InitializeMachine(_ context.Context, _ *driver.InitializeMachineRequest) (*driver.InitializeMachineResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "Metal Provider does not yet implement InitializeMachine")
 }
 
-func (d *metalDriver) GetVolumeIDs(_ context.Context, req *driver.GetVolumeIDsRequest) (*driver.GetVolumeIDsResponse, error) {
+func (d *metalDriver) GetVolumeIDs(_ context.Context, _ *driver.GetVolumeIDsRequest) (*driver.GetVolumeIDsResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "Metal Provider does not yet implement GetVolumeIDs")
 }
 
 // NewDriver returns a new Gardener metal driver object
-func NewDriver(cp *mcmclient.Provider, namespace string, useServerNameAsNodeName bool) driver.Driver {
+func NewDriver(cp *mcmclient.Provider, namespace string, nodeNamePolicy cmd.NodeNamePolicy) driver.Driver {
 	return &metalDriver{
-		clientProvider:          cp,
-		metalNamespace:          namespace,
-		useServerNameAsNodeName: useServerNameAsNodeName,
+		clientProvider: cp,
+		metalNamespace: namespace,
+		nodeNamePolicy: nodeNamePolicy,
 	}
 }
 

--- a/pkg/metal/driver.go
+++ b/pkg/metal/driver.go
@@ -30,9 +30,10 @@ var (
 )
 
 type metalDriver struct {
-	Schema         *runtime.Scheme
-	clientProvider *mcmclient.Provider
-	metalNamespace string
+	Schema                  *runtime.Scheme
+	clientProvider          *mcmclient.Provider
+	metalNamespace          string
+	useServerNameAsNodeName bool
 }
 
 func (d *metalDriver) InitializeMachine(ctx context.Context, request *driver.InitializeMachineRequest) (*driver.InitializeMachineResponse, error) {
@@ -44,10 +45,11 @@ func (d *metalDriver) GetVolumeIDs(_ context.Context, req *driver.GetVolumeIDsRe
 }
 
 // NewDriver returns a new Gardener metal driver object
-func NewDriver(cp *mcmclient.Provider, namespace string) driver.Driver {
+func NewDriver(cp *mcmclient.Provider, namespace string, useServerNameAsNodeName bool) driver.Driver {
 	return &metalDriver{
-		clientProvider: cp,
-		metalNamespace: namespace,
+		clientProvider:          cp,
+		metalNamespace:          namespace,
+		useServerNameAsNodeName: useServerNameAsNodeName,
 	}
 }
 
@@ -56,7 +58,7 @@ func (d *metalDriver) GenerateMachineClassForMigration(_ context.Context, _ *dri
 }
 
 func (d *metalDriver) getIgnitionNameForMachine(ctx context.Context, machineName string) string {
-	//for backward compatibility checking if ignition secret was already present with old naming convention
+	//for backward compatibility checking if the ignition secret was already present with the old naming convention
 	ignitionSecretName := fmt.Sprintf("%s-%s", machineName, "ignition")
 	d.clientProvider.Lock()
 	defer d.clientProvider.Unlock()

--- a/pkg/metal/get_machine_status.go
+++ b/pkg/metal/get_machine_status.go
@@ -40,9 +40,17 @@ func (d *metalDriver) GetMachineStatus(ctx context.Context, req *driver.GetMachi
 		return nil, status.Error(codes.Internal, err.Error())
 	}
 
+	nodeName := serverClaim.Name
+	if d.useServerNameAsNodeName {
+		if serverClaim.Spec.ServerRef == nil {
+			return nil, status.Error(codes.Internal, "server claim does not have a server ref")
+		}
+		nodeName = serverClaim.Spec.ServerRef.Name
+	}
+
 	return &driver.GetMachineStatusResponse{
 		ProviderID: getProviderIDForServerClaim(serverClaim),
-		NodeName:   serverClaim.Name,
+		NodeName:   nodeName,
 	}, nil
 }
 

--- a/pkg/metal/get_machine_status.go
+++ b/pkg/metal/get_machine_status.go
@@ -7,6 +7,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/ironcore-dev/machine-controller-manager-provider-ironcore-metal/pkg/cmd"
+
 	"github.com/gardener/machine-controller-manager/pkg/util/provider/driver"
 	"github.com/gardener/machine-controller-manager/pkg/util/provider/machinecodes/codes"
 	"github.com/gardener/machine-controller-manager/pkg/util/provider/machinecodes/status"
@@ -41,7 +43,7 @@ func (d *metalDriver) GetMachineStatus(ctx context.Context, req *driver.GetMachi
 	}
 
 	nodeName := serverClaim.Name
-	if d.useServerNameAsNodeName {
+	if d.nodeNamePolicy == cmd.NodeNamePolicyServerName {
 		if serverClaim.Spec.ServerRef == nil {
 			return nil, status.Error(codes.Internal, "server claim does not have a server ref")
 		}

--- a/pkg/metal/get_machine_status_test.go
+++ b/pkg/metal/get_machine_status_test.go
@@ -11,8 +11,12 @@ import (
 	"github.com/gardener/machine-controller-manager/pkg/util/provider/machinecodes/status"
 	"github.com/ironcore-dev/machine-controller-manager-provider-ironcore-metal/pkg/api/v1alpha1"
 	"github.com/ironcore-dev/machine-controller-manager-provider-ironcore-metal/pkg/metal/testing"
+	metalv1alpha1 "github.com/ironcore-dev/metal-operator/api/v1alpha1"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	. "sigs.k8s.io/controller-runtime/pkg/envtest/komega"
 )
 
 var _ = Describe("GetMachineStatus", func() {
@@ -28,6 +32,20 @@ var _ = Describe("GetMachineStatus", func() {
 		ret, err := (*drv).GetMachineStatus(ctx, emptyMacReq)
 		Expect(ret).To(BeNil())
 		Expect(err).Should(MatchError(status.Error(codes.InvalidArgument, "received empty request")))
+
+		By("starting a non-blocking goroutine to patch ServerClaim")
+		go func() {
+			defer GinkgoRecover()
+			serverClaim := &metalv1alpha1.ServerClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: ns.Name,
+					Name:      "machine-0",
+				},
+			}
+			Eventually(Update(serverClaim, func() {
+				serverClaim.Spec.ServerRef = &corev1.LocalObjectReference{Name: "foo"}
+			})).Should(Succeed())
+		}()
 
 		By("creating machine")
 		Expect((*drv).CreateMachine(ctx, &driver.CreateMachineRequest{
@@ -47,6 +65,48 @@ var _ = Describe("GetMachineStatus", func() {
 		})).To(Equal(&driver.GetMachineStatusResponse{
 			ProviderID: fmt.Sprintf("%s://%s/machine-%d", v1alpha1.ProviderName, ns.Name, 0),
 			NodeName:   "machine-0",
+		}))
+	})
+})
+
+var _ = Describe("GetMachineStatus using Server names", func() {
+	ns, providerSecret, drv := SetupTestUsingServerNames()
+
+	It("should create a machine and ensure status", func(ctx SpecContext) {
+		machineName := "machine-0"
+
+		By("starting a non-blocking goroutine to patch ServerClaim")
+		go func() {
+			defer GinkgoRecover()
+			serverClaim := &metalv1alpha1.ServerClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: ns.Name,
+					Name:      machineName,
+				},
+			}
+			Eventually(Update(serverClaim, func() {
+				serverClaim.Spec.ServerRef = &corev1.LocalObjectReference{Name: "foo"}
+			})).Should(Succeed())
+		}()
+
+		By("creating machine")
+		Expect((*drv).CreateMachine(ctx, &driver.CreateMachineRequest{
+			Machine:      newMachine(ns, "machine", -1, nil),
+			MachineClass: newMachineClass(v1alpha1.ProviderName, testing.SampleProviderSpec),
+			Secret:       providerSecret,
+		})).To(Equal(&driver.CreateMachineResponse{
+			ProviderID: fmt.Sprintf("%s://%s/machine-%d", v1alpha1.ProviderName, ns.Name, 0),
+			NodeName:   "foo",
+		}))
+
+		By("ensuring the machine status")
+		Expect((*drv).GetMachineStatus(ctx, &driver.GetMachineStatusRequest{
+			Machine:      newMachine(ns, "machine", -1, nil),
+			MachineClass: newMachineClass(v1alpha1.ProviderName, testing.SampleProviderSpec),
+			Secret:       providerSecret,
+		})).To(Equal(&driver.GetMachineStatusResponse{
+			ProviderID: fmt.Sprintf("%s://%s/machine-%d", v1alpha1.ProviderName, ns.Name, 0),
+			NodeName:   "foo",
 		}))
 	})
 })

--- a/pkg/metal/get_machine_status_test.go
+++ b/pkg/metal/get_machine_status_test.go
@@ -6,6 +6,8 @@ package metal
 import (
 	"fmt"
 
+	"github.com/ironcore-dev/machine-controller-manager-provider-ironcore-metal/pkg/cmd"
+
 	"github.com/gardener/machine-controller-manager/pkg/util/provider/driver"
 	"github.com/gardener/machine-controller-manager/pkg/util/provider/machinecodes/codes"
 	"github.com/gardener/machine-controller-manager/pkg/util/provider/machinecodes/status"
@@ -20,7 +22,7 @@ import (
 )
 
 var _ = Describe("GetMachineStatus", func() {
-	ns, providerSecret, drv := SetupTest()
+	ns, providerSecret, drv := SetupTest(cmd.NodeNamePolicyServerClaimName)
 
 	It("should create a machine and ensure status", func(ctx SpecContext) {
 		By("check empty request")
@@ -70,7 +72,7 @@ var _ = Describe("GetMachineStatus", func() {
 })
 
 var _ = Describe("GetMachineStatus using Server names", func() {
-	ns, providerSecret, drv := SetupTestUsingServerNames()
+	ns, providerSecret, drv := SetupTest(cmd.NodeNamePolicyServerName)
 
 	It("should create a machine and ensure status", func(ctx SpecContext) {
 		machineName := "machine-0"

--- a/pkg/metal/list_machines.go
+++ b/pkg/metal/list_machines.go
@@ -29,7 +29,7 @@ func (d *metalDriver) ListMachines(ctx context.Context, req *driver.ListMachines
 		return nil, status.Error(codes.InvalidArgument, fmt.Sprintf("provider spec for requested provider '%s' is invalid: %v", req.MachineClass.Provider, err))
 	}
 
-	// Get server claim list
+	// Get a server claim list
 	serverClaimList := &metalv1alpha1.ServerClaimList{}
 	matchingLabels := client.MatchingLabels{}
 	for k, v := range providerSpec.Labels {

--- a/pkg/metal/list_machines_test.go
+++ b/pkg/metal/list_machines_test.go
@@ -6,11 +6,16 @@ package metal
 import (
 	"fmt"
 
+	metalv1alpha1 "github.com/ironcore-dev/metal-operator/api/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"github.com/gardener/machine-controller-manager/pkg/util/provider/driver"
 	"github.com/ironcore-dev/machine-controller-manager-provider-ironcore-metal/pkg/api/v1alpha1"
 	"github.com/ironcore-dev/machine-controller-manager-provider-ironcore-metal/pkg/metal/testing"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	. "sigs.k8s.io/controller-runtime/pkg/envtest/komega"
 )
 
 var _ = Describe("ListMachines", func() {
@@ -36,6 +41,22 @@ var _ = Describe("ListMachines", func() {
 	})
 
 	It("should list a single machine if one has been created", func(ctx SpecContext) {
+		machineName := "machine-0"
+
+		By("starting a non-blocking goroutine to patch ServerClaim")
+		go func() {
+			defer GinkgoRecover()
+			serverClaim := &metalv1alpha1.ServerClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: ns.Name,
+					Name:      machineName,
+				},
+			}
+			Eventually(Update(serverClaim, func() {
+				serverClaim.Spec.ServerRef = &corev1.LocalObjectReference{Name: "foo"}
+			})).Should(Succeed())
+		}()
+
 		By("creating a machine")
 		craeteMachineResponse, err := (*drv).CreateMachine(ctx, &driver.CreateMachineRequest{
 			Machine:      newMachine(ns, "machine", -1, nil),
@@ -67,6 +88,23 @@ var _ = Describe("ListMachines", func() {
 	})
 
 	It("should list two machines if two have been created", func(ctx SpecContext) {
+		machineName := "machine-0"
+		machineName2 := "machine-1"
+
+		By("starting a non-blocking goroutine to patch ServerClaim")
+		go func() {
+			defer GinkgoRecover()
+			serverClaim := &metalv1alpha1.ServerClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: ns.Name,
+					Name:      machineName,
+				},
+			}
+			Eventually(Update(serverClaim, func() {
+				serverClaim.Spec.ServerRef = &corev1.LocalObjectReference{Name: "foo"}
+			})).Should(Succeed())
+		}()
+
 		By("creating the first machine")
 		craeteMachineResponse, err := (*drv).CreateMachine(ctx, &driver.CreateMachineRequest{
 			Machine:      newMachine(ns, "machine", 0, nil),
@@ -76,8 +114,21 @@ var _ = Describe("ListMachines", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(craeteMachineResponse).To(Equal(&driver.CreateMachineResponse{
 			ProviderID: fmt.Sprintf("%s://%s/machine-%d", v1alpha1.ProviderName, ns.Name, 0),
-			NodeName:   "machine-0",
+			NodeName:   machineName,
 		}))
+
+		go func() {
+			defer GinkgoRecover()
+			serverClaim := &metalv1alpha1.ServerClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: ns.Name,
+					Name:      machineName2,
+				},
+			}
+			Eventually(Update(serverClaim, func() {
+				serverClaim.Spec.ServerRef = &corev1.LocalObjectReference{Name: "foo-2"}
+			})).Should(Succeed())
+		}()
 
 		By("creating the second machine")
 		craeteMachineResponse, err = (*drv).CreateMachine(ctx, &driver.CreateMachineRequest{
@@ -88,7 +139,7 @@ var _ = Describe("ListMachines", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(craeteMachineResponse).To(Equal(&driver.CreateMachineResponse{
 			ProviderID: fmt.Sprintf("%s://%s/machine-%d", v1alpha1.ProviderName, ns.Name, 1),
-			NodeName:   "machine-1",
+			NodeName:   machineName2,
 		}))
 
 		By("ensuring the machine status contains 2 machines")
@@ -98,8 +149,8 @@ var _ = Describe("ListMachines", func() {
 		})
 		Expect(err).NotTo(HaveOccurred())
 		Expect(listMachinesResponse.MachineList).To(Equal(map[string]string{
-			fmt.Sprintf("%s://%s/machine-%d", v1alpha1.ProviderName, ns.Name, 0): "machine-0",
-			fmt.Sprintf("%s://%s/machine-%d", v1alpha1.ProviderName, ns.Name, 1): "machine-1",
+			fmt.Sprintf("%s://%s/machine-%d", v1alpha1.ProviderName, ns.Name, 0): machineName,
+			fmt.Sprintf("%s://%s/machine-%d", v1alpha1.ProviderName, ns.Name, 1): machineName2,
 		}))
 
 		By("ensuring the cleanup of the first machine")

--- a/pkg/metal/list_machines_test.go
+++ b/pkg/metal/list_machines_test.go
@@ -19,7 +19,7 @@ import (
 )
 
 var _ = Describe("ListMachines", func() {
-	ns, providerSecret, drv := SetupTest()
+	ns, providerSecret, drv := SetupTest("")
 
 	It("should fail if no provider has been set", func(ctx SpecContext) {
 		By("ensuring an error if no provider has been set")

--- a/pkg/metal/testing/testing.go
+++ b/pkg/metal/testing/testing.go
@@ -112,4 +112,80 @@ WantedBy=multi-user.target
 			},
 		},
 	}
+
+	SampleIgnitionWithFooHostname = map[string]interface{}{
+		"ignition": map[string]interface{}{
+			"version": "3.2.0",
+		},
+		"passwd": map[string]interface{}{
+			"users": []interface{}{
+				map[string]interface{}{
+					"groups": []interface{}{"group1"},
+					"name":   "xyz",
+					"shell":  "/bin/bash",
+				},
+			},
+		},
+		"storage": map[string]interface{}{
+			"files": []interface{}{
+				map[string]interface{}{
+					"overwrite": true,
+					"path":      "/etc/hostname",
+					"contents": map[string]interface{}{
+						"compression": "",
+						"source":      "data:,foo%0A",
+					},
+					"mode": 420.0,
+				},
+				map[string]interface{}{
+					"overwrite": true,
+					"path":      "/var/lib/metal-cloud-config/init.sh",
+					"contents": map[string]interface{}{
+						"source":      "data:,abcd%0A",
+						"compression": "",
+					},
+					"mode": 493.0,
+				},
+				map[string]interface{}{
+					"path": "/etc/systemd/resolved.conf.d/dns.conf",
+					"contents": map[string]interface{}{
+						"compression": "",
+						"source":      "data:,%5BResolve%5D%0ADNS%3D1.2.3.4%0ADNS%3D5.6.7.8",
+					},
+					"mode": 420.0,
+				},
+				map[string]interface{}{
+					"path": "/var/lib/metal-cloud-config/metadata",
+					"contents": map[string]interface{}{
+						"compression": "",
+						"source":      "data:;base64,eyJiYXoiOiIxMDAiLCJmb28iOiJiYXIifQ==",
+					},
+					"mode": 420.0,
+				},
+			},
+		},
+		"systemd": map[string]interface{}{
+			"units": []interface{}{
+				map[string]interface{}{
+					"contents": `[Unit]
+Wants=network-online.target
+After=network-online.target
+ConditionPathExists=!/var/lib/metal-cloud-config/init.done
+
+[Service]
+Type=oneshot
+ExecStart=/var/lib/metal-cloud-config/init.sh
+ExecStopPost=touch /var/lib/metal-cloud-config/init.done
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target
+`,
+					"enabled": true,
+					"name":    "cloud-config-init.service",
+				},
+			},
+		},
+	}
 )


### PR DESCRIPTION
# Proposed Changes

This PR introduces a new flag to the MCM driver
(`node-name-policy`) which uses the underlying `Server` name as the `Node` name instead of relying on the `ServerClaim` name.

In this context the `CreateMachine` flow has been slightly modified as it uses now a `wait.PollUntilContextTimeout` when creating a `ServerClaim`. That way we can be sure, that a `Server` has been successfully assigned to a `ServerClaim`.

/ref https://github.com/ironcore-dev/boot-operator/pull/190