### PR TITLE
Add optional `Server` loopback address to metadata

### DIFF
--- a/pkg/api/v1alpha1/provider.go
+++ b/pkg/api/v1alpha1/provider.go
@@ -12,6 +12,8 @@ const (
 	V1Alpha1 = "mcm.gardener.cloud/v1alpha1"
 	// ProviderName is the provider name
 	ProviderName = "ironcore-metal"
+	// LoopbackAddressAnnotation is the annotation used to specify a loopback address for the Machine
+	LoopbackAddressAnnotation = "metal.ironcore.dev/loopback-address"
 )
 
 // ProviderSpec is the spec to be used while parsing the calls

--- a/pkg/metal/create_machine_test.go
+++ b/pkg/metal/create_machine_test.go
@@ -29,6 +29,17 @@ var _ = Describe("CreateMachine", func() {
 
 	It("should create a machine", func(ctx SpecContext) {
 		machineName := "machine-0"
+		By("creating a server")
+		server := &metalv1alpha1.Server{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test-server",
+			},
+			Spec: metalv1alpha1.ServerSpec{
+				SystemUUID: "12345",
+			},
+		}
+		Expect(k8sClient.Create(ctx, server)).To(Succeed())
+		DeferCleanup(k8sClient.Delete, server)
 
 		By("starting a non-blocking goroutine to patch ServerClaim")
 		go func() {
@@ -40,7 +51,7 @@ var _ = Describe("CreateMachine", func() {
 				},
 			}
 			Eventually(Update(serverClaim, func() {
-				serverClaim.Spec.ServerRef = &corev1.LocalObjectReference{Name: "foo"}
+				serverClaim.Spec.ServerRef = &corev1.LocalObjectReference{Name: server.Name}
 			})).Should(Succeed())
 		}()
 
@@ -88,7 +99,86 @@ var _ = Describe("CreateMachine", func() {
 		Eventually(Object(ignition)).Should(SatisfyAll(
 			HaveField("Data", HaveKeyWithValue("ignition", MatchJSON(ignitionData))),
 		))
+	})
 
+	It("should create a machine with correct meta data", func(ctx SpecContext) {
+		machineName := "machine-0"
+		By("creating a server")
+		server := &metalv1alpha1.Server{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test-server",
+				Annotations: map[string]string{
+					v1alpha1.LoopbackAddressAnnotation: "2001:db8::1",
+				},
+			},
+			Spec: metalv1alpha1.ServerSpec{
+				SystemUUID: "12345",
+			},
+		}
+		Expect(k8sClient.Create(ctx, server)).To(Succeed())
+		DeferCleanup(k8sClient.Delete, server)
+
+		By("starting a non-blocking goroutine to patch ServerClaim")
+		go func() {
+			defer GinkgoRecover()
+			serverClaim := &metalv1alpha1.ServerClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: ns.Name,
+					Name:      machineName,
+				},
+			}
+			Eventually(Update(serverClaim, func() {
+				serverClaim.Spec.ServerRef = &corev1.LocalObjectReference{Name: server.Name}
+			})).Should(Succeed())
+		}()
+
+		By("creating machine")
+		Expect((*drv).CreateMachine(ctx, &driver.CreateMachineRequest{
+			Machine:      newMachine(ns, "machine", -1, nil),
+			MachineClass: newMachineClass(v1alpha1.ProviderName, testing.SampleProviderSpec),
+			Secret:       providerSecret,
+		})).To(Equal(&driver.CreateMachineResponse{
+			ProviderID: fmt.Sprintf("%s://%s/machine-%d", v1alpha1.ProviderName, ns.Name, 0),
+			NodeName:   machineName,
+		}))
+
+		By("ensuring that a server claim has been created")
+		serverClaim := &metalv1alpha1.ServerClaim{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      machineName,
+				Namespace: ns.Name,
+			},
+		}
+
+		Eventually(Object(serverClaim)).Should(SatisfyAll(
+			HaveField("ObjectMeta.Labels", map[string]string{
+				ShootNameLabelKey:      "my-shoot",
+				ShootNamespaceLabelKey: "my-shoot-namespace",
+			}),
+			HaveField("Spec.Power", metalv1alpha1.PowerOn),
+			HaveField("Spec.ServerSelector", &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"instance-type": "bar",
+				},
+			}),
+		))
+
+		By("ensuring that the ignition secret has been created")
+		ignition := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: ns.Name,
+				Name:      machineName,
+			},
+		}
+
+		ignitionData, err := json.Marshal(testing.SampleIgnitionWithServerMetadata)
+		Expect(err).NotTo(HaveOccurred())
+		Eventually(Object(ignition)).Should(SatisfyAll(
+			HaveField("Data", HaveKeyWithValue("ignition", MatchJSON(ignitionData))),
+		))
+	})
+
+	It("should fail if the machine request is empty", func(ctx SpecContext) {
 		By("failing if the machine request is empty")
 		Eventually(func(g Gomega) {
 			_, err := (*drv).CreateMachine(ctx, nil)
@@ -96,7 +186,7 @@ var _ = Describe("CreateMachine", func() {
 		}).Should(Succeed())
 	})
 
-	It("should fail if the machine class is empty", func(ctx SpecContext) {
+	It("should fail if the machine request has a wrong provider", func(ctx SpecContext) {
 		By("failing if the wrong provider is set")
 		Eventually(func(g Gomega) {
 			_, err := (*drv).CreateMachine(ctx, &driver.CreateMachineRequest{
@@ -111,6 +201,18 @@ var _ = Describe("CreateMachine", func() {
 	When("capi ipam references are present in ipamConfig", func() {
 		It("should create ip claims and an ignition with ips", func(ctx SpecContext) {
 			machineName := "machine-0"
+			By("creating a server")
+			server := &metalv1alpha1.Server{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-server",
+				},
+				Spec: metalv1alpha1.ServerSpec{
+					SystemUUID: "12345",
+				},
+			}
+			Expect(k8sClient.Create(ctx, server)).To(Succeed())
+			DeferCleanup(k8sClient.Delete, server)
+
 			sampleProviderSpec := maps.Clone(testing.SampleProviderSpec)
 			delete(sampleProviderSpec, "metaData")
 
@@ -138,7 +240,7 @@ var _ = Describe("CreateMachine", func() {
 					},
 				}
 				Eventually(Update(serverClaim, func() {
-					serverClaim.Spec.ServerRef = &corev1.LocalObjectReference{Name: "foo"}
+					serverClaim.Spec.ServerRef = &corev1.LocalObjectReference{Name: server.Name}
 				})).Should(Succeed())
 			}()
 
@@ -215,6 +317,17 @@ var _ = Describe("CreateMachine with Server name as hostname", func() {
 
 	It("should create a machine", func(ctx SpecContext) {
 		machineName := "machine-0"
+		By("creating a server")
+		server := &metalv1alpha1.Server{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test-server",
+			},
+			Spec: metalv1alpha1.ServerSpec{
+				SystemUUID: "12345",
+			},
+		}
+		Expect(k8sClient.Create(ctx, server)).To(Succeed())
+		DeferCleanup(k8sClient.Delete, server)
 
 		By("starting a non-blocking goroutine to patch ServerClaim")
 		go func() {
@@ -226,7 +339,7 @@ var _ = Describe("CreateMachine with Server name as hostname", func() {
 				},
 			}
 			Eventually(Update(serverClaim, func() {
-				serverClaim.Spec.ServerRef = &corev1.LocalObjectReference{Name: "foo"}
+				serverClaim.Spec.ServerRef = &corev1.LocalObjectReference{Name: server.Name}
 			})).Should(Succeed())
 		}()
 
@@ -237,7 +350,7 @@ var _ = Describe("CreateMachine with Server name as hostname", func() {
 			Secret:       providerSecret,
 		})).To(Equal(&driver.CreateMachineResponse{
 			ProviderID: fmt.Sprintf("%s://%s/machine-%d", v1alpha1.ProviderName, ns.Name, 0),
-			NodeName:   "foo",
+			NodeName:   server.Name,
 		}))
 
 		By("ensuring that a server claim has been created")
@@ -269,7 +382,7 @@ var _ = Describe("CreateMachine with Server name as hostname", func() {
 			},
 		}
 
-		ignitionData, err := json.Marshal(testing.SampleIgnitionWithFooHostname)
+		ignitionData, err := json.Marshal(testing.SampleIgnitionWithTestServerHostname)
 		Expect(err).NotTo(HaveOccurred())
 		Eventually(Object(ignition)).Should(SatisfyAll(
 			HaveField("Data", HaveKeyWithValue("ignition", MatchJSON(ignitionData))),
@@ -280,6 +393,5 @@ var _ = Describe("CreateMachine with Server name as hostname", func() {
 			_, err := (*drv).CreateMachine(ctx, nil)
 			g.Expect(err.Error()).To(ContainSubstring("received empty request"))
 		}).Should(Succeed())
-
 	})
 })

--- a/pkg/metal/delete_machine_test.go
+++ b/pkg/metal/delete_machine_test.go
@@ -23,6 +23,17 @@ var _ = Describe("DeleteMachine", func() {
 
 	It("should create and delete a machine", func(ctx SpecContext) {
 		machineName := "machine-0"
+		By("creating a server")
+		server := &metalv1alpha1.Server{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test-server",
+			},
+			Spec: metalv1alpha1.ServerSpec{
+				SystemUUID: "12345",
+			},
+		}
+		Expect(k8sClient.Create(ctx, server)).To(Succeed())
+		DeferCleanup(k8sClient.Delete, server)
 
 		go func() {
 			defer GinkgoRecover()
@@ -33,7 +44,7 @@ var _ = Describe("DeleteMachine", func() {
 				},
 			}
 			Eventually(Update(serverClaim, func() {
-				serverClaim.Spec.ServerRef = &corev1.LocalObjectReference{Name: "foo"}
+				serverClaim.Spec.ServerRef = &corev1.LocalObjectReference{Name: server.Name}
 			})).Should(Succeed())
 		}()
 
@@ -77,8 +88,19 @@ var _ = Describe("DeleteMachine", func() {
 		Eventually(Get(ignition)).Should(Satisfy(apierrors.IsNotFound))
 	})
 
-	It("should create and delete a machine igntition secret created with old naming convention", func(ctx SpecContext) {
+	It("should create and delete a machine ignition secret created with old naming convention", func(ctx SpecContext) {
 		machineName := "machine-0"
+		By("creating a server")
+		server := &metalv1alpha1.Server{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test-server",
+			},
+			Spec: metalv1alpha1.ServerSpec{
+				SystemUUID: "12345",
+			},
+		}
+		Expect(k8sClient.Create(ctx, server)).To(Succeed())
+		DeferCleanup(k8sClient.Delete, server)
 
 		By("creating an ignition secret")
 		ignition := &corev1.Secret{
@@ -98,7 +120,7 @@ var _ = Describe("DeleteMachine", func() {
 				},
 			}
 			Eventually(Update(serverClaim, func() {
-				serverClaim.Spec.ServerRef = &corev1.LocalObjectReference{Name: "foo"}
+				serverClaim.Spec.ServerRef = &corev1.LocalObjectReference{Name: server.Name}
 			})).Should(Succeed())
 		}()
 

--- a/pkg/metal/list_machines_test.go
+++ b/pkg/metal/list_machines_test.go
@@ -42,6 +42,17 @@ var _ = Describe("ListMachines", func() {
 
 	It("should list a single machine if one has been created", func(ctx SpecContext) {
 		machineName := "machine-0"
+		By("creating a server")
+		server := &metalv1alpha1.Server{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test-server",
+			},
+			Spec: metalv1alpha1.ServerSpec{
+				SystemUUID: "12345",
+			},
+		}
+		Expect(k8sClient.Create(ctx, server)).To(Succeed())
+		DeferCleanup(k8sClient.Delete, server)
 
 		By("starting a non-blocking goroutine to patch ServerClaim")
 		go func() {
@@ -53,7 +64,7 @@ var _ = Describe("ListMachines", func() {
 				},
 			}
 			Eventually(Update(serverClaim, func() {
-				serverClaim.Spec.ServerRef = &corev1.LocalObjectReference{Name: "foo"}
+				serverClaim.Spec.ServerRef = &corev1.LocalObjectReference{Name: server.Name}
 			})).Should(Succeed())
 		}()
 
@@ -90,6 +101,29 @@ var _ = Describe("ListMachines", func() {
 	It("should list two machines if two have been created", func(ctx SpecContext) {
 		machineName := "machine-0"
 		machineName2 := "machine-1"
+		By("creating a server")
+		server := &metalv1alpha1.Server{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test-server",
+			},
+			Spec: metalv1alpha1.ServerSpec{
+				SystemUUID: "12345",
+			},
+		}
+		Expect(k8sClient.Create(ctx, server)).To(Succeed())
+		DeferCleanup(k8sClient.Delete, server)
+
+		By("creating a server")
+		server2 := &metalv1alpha1.Server{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test-server-2",
+			},
+			Spec: metalv1alpha1.ServerSpec{
+				SystemUUID: "12345",
+			},
+		}
+		Expect(k8sClient.Create(ctx, server2)).To(Succeed())
+		DeferCleanup(k8sClient.Delete, server2)
 
 		By("starting a non-blocking goroutine to patch ServerClaim")
 		go func() {
@@ -101,7 +135,7 @@ var _ = Describe("ListMachines", func() {
 				},
 			}
 			Eventually(Update(serverClaim, func() {
-				serverClaim.Spec.ServerRef = &corev1.LocalObjectReference{Name: "foo"}
+				serverClaim.Spec.ServerRef = &corev1.LocalObjectReference{Name: server.Name}
 			})).Should(Succeed())
 		}()
 
@@ -126,7 +160,7 @@ var _ = Describe("ListMachines", func() {
 				},
 			}
 			Eventually(Update(serverClaim, func() {
-				serverClaim.Spec.ServerRef = &corev1.LocalObjectReference{Name: "foo-2"}
+				serverClaim.Spec.ServerRef = &corev1.LocalObjectReference{Name: server2.Name}
 			})).Should(Succeed())
 		}()
 

--- a/pkg/metal/testing/testing.go
+++ b/pkg/metal/testing/testing.go
@@ -113,7 +113,7 @@ WantedBy=multi-user.target
 		},
 	}
 
-	SampleIgnitionWithFooHostname = map[string]interface{}{
+	SampleIgnitionWithServerMetadata = map[string]interface{}{
 		"ignition": map[string]interface{}{
 			"version": "3.2.0",
 		},
@@ -133,7 +133,83 @@ WantedBy=multi-user.target
 					"path":      "/etc/hostname",
 					"contents": map[string]interface{}{
 						"compression": "",
-						"source":      "data:,foo%0A",
+						"source":      "data:,machine-0%0A",
+					},
+					"mode": 420.0,
+				},
+				map[string]interface{}{
+					"overwrite": true,
+					"path":      "/var/lib/metal-cloud-config/init.sh",
+					"contents": map[string]interface{}{
+						"source":      "data:,abcd%0A",
+						"compression": "",
+					},
+					"mode": 493.0,
+				},
+				map[string]interface{}{
+					"path": "/etc/systemd/resolved.conf.d/dns.conf",
+					"contents": map[string]interface{}{
+						"compression": "",
+						"source":      "data:,%5BResolve%5D%0ADNS%3D1.2.3.4%0ADNS%3D5.6.7.8",
+					},
+					"mode": 420.0,
+				},
+				map[string]interface{}{
+					"path": "/var/lib/metal-cloud-config/metadata",
+					"contents": map[string]interface{}{
+						"compression": "",
+						"source":      "data:;base64,eyJiYXoiOiIxMDAiLCJmb28iOiJiYXIiLCJsb29wYmFja0FkZHJlc3MiOiIyMDAxOmRiODo6MSJ9",
+					},
+					"mode": 420.0,
+				},
+			},
+		},
+		"systemd": map[string]interface{}{
+			"units": []interface{}{
+				map[string]interface{}{
+					"contents": `[Unit]
+Wants=network-online.target
+After=network-online.target
+ConditionPathExists=!/var/lib/metal-cloud-config/init.done
+
+[Service]
+Type=oneshot
+ExecStart=/var/lib/metal-cloud-config/init.sh
+ExecStopPost=touch /var/lib/metal-cloud-config/init.done
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target
+`,
+					"enabled": true,
+					"name":    "cloud-config-init.service",
+				},
+			},
+		},
+	}
+
+	SampleIgnitionWithTestServerHostname = map[string]interface{}{
+		"ignition": map[string]interface{}{
+			"version": "3.2.0",
+		},
+		"passwd": map[string]interface{}{
+			"users": []interface{}{
+				map[string]interface{}{
+					"groups": []interface{}{"group1"},
+					"name":   "xyz",
+					"shell":  "/bin/bash",
+				},
+			},
+		},
+		"storage": map[string]interface{}{
+			"files": []interface{}{
+				map[string]interface{}{
+					"overwrite": true,
+					"path":      "/etc/hostname",
+					"contents": map[string]interface{}{
+						"compression": "",
+						"source":      "data:,test-server%0A",
 					},
 					"mode": 420.0,
 				},


### PR DESCRIPTION
# Proposed Changes

Add optional `Server` loopback address to metadata which is derived from the `Server.Annotation` `metal.ironcore.dev/loopback-address`.