### PR TITLE
Consider claim power setting for machine status

### DIFF
--- a/pkg/metal/get_machine_status.go
+++ b/pkg/metal/get_machine_status.go
@@ -40,6 +40,10 @@ func (d *metalDriver) GetMachineStatus(ctx context.Context, req *driver.GetMachi
 		return nil, status.Error(codes.Internal, err.Error())
 	}
 
+	if serverClaim.Spec.Power != metalv1alpha1.PowerOn {
+		return nil, status.Error(codes.Internal, fmt.Sprintf("server claim %q is not powered on", req.Machine.Name))
+	}
+
 	nodeName, err := GetNodeName(ctx, d.nodeNamePolicy, serverClaim, d.metalNamespace, d.clientProvider.Client)
 	if err != nil {
 		return nil, status.Error(codes.Internal, fmt.Sprintf("failed to get node name: %v", err))


### PR DESCRIPTION
# Proposed Changes

- The machine creation isn't retried right now, once the server claim exist. Setting power to on is the last step in the create flow, so checking for that should cause failed creations to be retried eventually.